### PR TITLE
fix the bug where some bugreports cannot be processed, following the cl

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run the Battery Historian image. Choose a port number and replace `<port>` with
 that number in the commands below:
 
 ```
-docker -- run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
+docker run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
 ```
 
 For Linux and Mac OS X:
@@ -272,4 +272,3 @@ $ go run cmd/checkin-delta/local_checkin_delta.go --input=bugreport_1.txt,bugrep
 
 If you've found an error in this project, please file an issue:
 <https://github.com/google/battery-historian/issues>
-

--- a/checkinparse/checkin_parse.go
+++ b/checkinparse/checkin_parse.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC. All Rights Reserved.
+// Copyright 2016-2020 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -589,10 +589,7 @@ func ParseBatteryStats(pc checkinutil.Counter, cr *checkinutil.BatteryReport, pk
 		// Parse csv lines according to
 		// frameworks/base/core/java/android/os/BatteryStats.java.
 		parsed, warn, csErrs := parseSection(pc, reportVersion, rawUID, section, remaining, stats, system, apkSeen, &allAppComputedPowerMah)
-		e := false
-		if e, warnings, errs = saveWarningsAndErrors(warnings, warn, errs, csErrs...); e {
-			return nil, warnings, errs
-		}
+		_, warnings, errs = saveWarningsAndErrors(warnings, warn, errs, csErrs...)
 		if !parsed {
 			warnings = append(warnings, fmt.Sprintf("unknown data category %s", section))
 		}

--- a/setup.go
+++ b/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC. All Rights Reserved.
+// Copyright 2016-2020 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import (
 
 const (
 	closureCompilerVersion = "20170409"
+	closureLibraryVersion  = "v" + closureCompilerVersion
 	closureCompilerZip     = "compiler-" + closureCompilerVersion + ".zip"
 	closureCompilerJar     = "closure-compiler-v" + closureCompilerVersion + ".jar"
 	closureCompilerURL     = "http://dl.google.com/closure-compiler/" + closureCompilerZip
@@ -113,6 +114,10 @@ func main() {
 	if _, err := os.Stat(closureLibraryDir); os.IsNotExist(err) {
 		fmt.Println("\nDownloading Closure library...")
 		runCommand("git", "clone", "https://github.com/google/closure-library", closureLibraryDir)
+		// Make sure the libbrary and compiler versions are the same
+		os.Chdir(closureLibraryDir)
+		runCommand("git", "reset", "--hard", closureLibraryVersion)
+		os.Chdir(wd)
 	}
 
 	_, errD := os.Stat(closureCompilerDir)


### PR DESCRIPTION
1. Change the year of the header License for the three files to be 2016-2020.
2. Change the three file corresponding to the CL. Bugreports can all be processed now.