### PR TITLE
[1] Helper function in historianutils.go for computing rate/frequency from period

### DIFF
--- a/historianutils/historianutils.go
+++ b/historianutils/historianutils.go
@@ -110,9 +110,13 @@ func MaxInt64(a int64, b int64) int64 {
 	return b
 }
 
-// RoundFloat returns the closest integer to the given float number.
-func RoundFloat(val float64) int32 {
-	return int32(math.Round(val))
+// PeriodUsToRateHz takes in the period in us and returns the frequency in Hz.
+// Note that if period is 0 or -1, then the rate is set to be -1.
+func PeriodUsToRateHz(period int) float64 {
+	if period == 0 || period == -1 {
+		return -1
+	}
+	return math.Round(100/(1e-06*float64(period))) / 100
 }
 
 // ParseDurationWithDays parses a duration string and returns the milliseconds. e.g. 3d1h2m

--- a/historianutils/historianutils.go
+++ b/historianutils/historianutils.go
@@ -112,11 +112,12 @@ func MaxInt64(a int64, b int64) int64 {
 
 // PeriodUsToRateHz takes in the period in us and returns the frequency in Hz.
 // Note that if period is 0 or -1, then the rate is set to be -1.
-func PeriodUsToRateHz(period int) float64 {
-	if period == 0 || period == -1 {
+func PeriodUsToRateHz(periodUs int) float64 {
+	if periodUs == 0 || periodUs == -1 {
 		return -1
 	}
-	return math.Round(100/(1e-06*float64(period))) / 100
+	periodS := 1e-06 * float64(periodUs)
+	return math.Round(100/periodS) / 100
 }
 
 // ParseDurationWithDays parses a duration string and returns the milliseconds. e.g. 3d1h2m

--- a/historianutils/historianutils.go
+++ b/historianutils/historianutils.go
@@ -111,6 +111,7 @@ func MaxInt64(a int64, b int64) int64 {
 }
 
 // PeriodUsToRateHz takes in the period in us and returns the frequency in Hz.
+// The frequency returned is rounded to 2 decimal places.
 // Note that if period is 0 or -1, then the rate is set to be -1.
 func PeriodUsToRateHz(periodUs int) float64 {
 	if periodUs == 0 || periodUs == -1 {

--- a/historianutils/historianutils_test.go
+++ b/historianutils/historianutils_test.go
@@ -18,30 +18,6 @@ import (
 	"testing"
 )
 
-func TestRounding(t *testing.T) {
-	tests := []struct {
-		input float64
-		want  int32
-	}{
-		{input: 1.999,
-			want: 2},
-		{input: -1.999,
-			want: -2},
-		{input: 1.499,
-			want: 1},
-		{input: -1.499,
-			want: -1},
-		{input: 666666.667,
-			want: 666667},
-	}
-	for _, test := range tests {
-		result := RoundFloat(test.input)
-		if result != test.want {
-			t.Errorf("input:%v\n  got: %v\n  want: %v", test.input, result, test.want)
-		}
-	}
-}
-
 func TestScrubPII(t *testing.T) {
 	test := map[string]string{
 		"pureemail@google.com":   "XXX@google.com",


### PR DESCRIPTION
This is a small PR where I remove the function for rounding and add a function that computes rate(frequency) in Hz given a period value in microseconds.
Note that I am using math.Round(100 / periodS) / 100 to make sure that the float64 value is rounded to 2 decimal places. 