### PR TITLE
Frontend done for filter-by-app feature and error visualization

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -1026,6 +1026,8 @@ func (pd *ParsedData) parseBugReport(fnameA, contentsA, fnameB, contentsB string
 	return nil
 }
 
+// constructAppName takes in a list of all app information and update the app
+// name in the output produced after parsing sensorservice dump.
 func constructAppName(output sensorserviceutils.OutputData,
 	appStats []presenter.AppStat) sensorserviceutils.OutputData {
 	for _, outputApp := range output.SensorInfo.Apps {
@@ -1038,6 +1040,8 @@ func constructAppName(output sensorserviceutils.OutputData,
 	return output
 }
 
+// analyze takes in the bugreport and information for all packages and produce
+// summary data for battery usage activity found in the bugreport.
 func analyze(bugReport string, pkgs []*usagepb.PackageInfo) summariesData {
 	upm, errs := parseutils.UIDAndPackageNameMapping(bugReport, pkgs)
 

--- a/js/bar_data.js
+++ b/js/bar_data.js
@@ -377,8 +377,9 @@ historian.BarData.METRICS_SELECTOR_ = 'select.configure-metrics';
 historian.BarData.APP_FILTER_ID_ = '#filter-by-app';
 
 /**
- * Set up the app filter selector. With a selected app, the graph only display
- * sensor information for those have subscription activities with the chosen app.
+ * Sets up the app filter selector. With a selected app, the graph only display
+ * sensor information for those sensors that have subscription activities 
+ * with the chosen app.
  * @param {!Object<boolean>} hidden Groups hidden.
  * @private
  */

--- a/js/bar_data.js
+++ b/js/bar_data.js
@@ -83,6 +83,11 @@ historian.BarData = function(container, groups, hidden, order, createList) {
   /** @private {boolean} */
   this.filter_ = true;
 
+  /** @param {!Object<boolean>} */
+  this.oldHidden_ = hidden;
+
+  this.setUpAppFilter();
+
   this.generateDataToDisplay_(hidden);
   // Assign a row index to each series group.
   this.generateIndexes();
@@ -368,6 +373,63 @@ historian.BarData.prototype.getMaxIndex = function() {
 /** @private @const {string} */
 historian.BarData.METRICS_SELECTOR_ = 'select.configure-metrics';
 
+/** @private @const {string} */
+historian.BarData.APP_FILTER_ID_ = '#filter-by-app';
+
+/**
+ * Set up the app filter selector. With a selected app, the graph only display
+ * sensor information for those have subscription activities with the chosen app.
+ * @param {!Object<boolean>} hidden Groups hidden.
+ * @private
+ */
+historian.BarData.prototype.setUpAppFilter = function(hidden) {
+  // Filter-by-app selector is for historian-sensor tab only.
+  if (!$(this.container_).attr('id').includes('sensor')) {
+    return;
+  }
+
+  var select = $(historian.BarData.APP_FILTER_ID_);
+  select.on('change', function(event) {
+    if (!event.val) {
+      hidden = this.oldHidden_;
+      this.generateDataToDisplay_(hidden);
+      this.callListeners_();
+      return;
+    }
+    hidden = this.oldHidden_;
+    var uid = parseInt(event.val, 10);
+    var app;
+    historian.sensorsInfo.Apps.forEach(function(appObj) {
+      if (uid == 0){
+        // Handle the case where if the uid = 0, proto buf structure for app
+        // does not have the field for UID.
+        if (!appObj.UID) {
+          app = appObj;
+        }
+      } else if (appObj.UID == uid) {
+        app = appObj;
+      }
+    });
+
+    var sensorsForApp = app.SensorActivities.map(sensor => String(sensor));
+    this.order_.forEach(function(groupProp) {
+      var group = this.getGroups_().get(groupProp.source, groupProp.name);
+      if (!sensorsForApp.includes(group.name)) {
+        this.removeGroup(group.source, group.name);
+        hidden[historian.metrics.hash(group)] = true;
+      } else{
+        this.addGroup(group.source, group.name);
+        hidden[historian.metrics.hash(group)] = false;
+        var select = this.container_.find(historian.BarData.METRICS_SELECTOR_);
+        var remove = this.groupDesc_({name: group.name, source: group.source});
+        select.find('option[value="' + remove + '"]').remove();
+        select.select2('val', null);
+      }
+    }, this);
+    this.generateDataToDisplay_(hidden);
+    this.callListeners_();
+  }.bind(this));
+};
 
 /**
  * Creates the series selector for adding hidden groups.
@@ -386,7 +448,11 @@ historian.BarData.prototype.addSeriesSelector_ = function(hidden) {
     return historian.metrics.hash(group) in hidden ? res.concat(group) : res;
   }, []);
   var selectNames = groups.map(this.groupDesc_).sort();
-  historian.utils.setupDropdown(select, selectNames, 'Add Metrics');
+  if (this.container_.attr('id').includes("sensor")) {
+    historian.utils.setupDropdown(select, selectNames, 'Add Sensors');
+  } else {
+    historian.utils.setupDropdown(select, selectNames, 'Add Metrics');
+  }
   select.on('change', function(event) {
     if (!event.val) {
       return;

--- a/js/bars.js
+++ b/js/bars.js
@@ -158,8 +158,7 @@ historian.Bars = function(context, barData, levelData, timeToDelta, state,
         if (isValid) {
           this.updateSeries_();
         }
-      }
-    .bind(this));
+      }.bind(this));
   }
 };
 

--- a/js/historian_v2.js
+++ b/js/historian_v2.js
@@ -77,6 +77,12 @@ historian.HistorianV2 = function(container, data, levelSummaryData, state,
   /** @private {?number} */
   this.overflowMs_ = data.overflowMs;
 
+  // Construct a selector for app on the sensor historian tab to 
+  // support filtering feature.
+  if ($(this.container_).attr('id').includes('sensor')) {
+    this.setupFilterByAppForSensorHistorian_();
+  }
+
   historian.color.generateSeriesColors(this.data_.barGroups);
 
   /** @private {!historian.BarData} */
@@ -118,6 +124,7 @@ historian.HistorianV2 = function(container, data, levelSummaryData, state,
                                   this.state_,
                                   powerEstimator,
                                   this.container_);
+                                  
   /** @private {!historian.LevelLine} */
   this.levelLine_ = new historian.LevelLine(this.context_, this.levelData_,
       this.levelSummaryData_, showReportTaken, this.overflowMs_,
@@ -382,3 +389,36 @@ historian.HistorianV2.prototype.handleMouse_ = function() {
         this.levelLine_.hideTimeInfo();
       }.bind(this));
 };
+
+/**
+ * Create the selector to support filtering by app feature 
+ * for sensor historian tab.
+ * @private
+ */
+historian.HistorianV2.prototype.setupFilterByAppForSensorHistorian_ = function (){
+  var settings = $(this.container_).find('.settings');
+  var newSpan = $('<span/>');
+  newSpan.addClass('settings-section');
+  var newSelect = $('<select/>');
+  newSelect.attr('id', 'filter-by-app');
+  newSelect.addClass('filter-by-app');
+  settings.prepend(newSpan.append(newSelect));
+
+  // Set up the dropdown option list for the selector.
+  var filterAppSelector = $('#filter-by-app');
+  filterAppSelector.empty().append('<option></option>');
+  filterAppSelector.select2({
+    placeholder: 'Choose an application',
+    allowClear: true,
+    dropdownAutoWidth: true,
+  });
+  var allAppOptions = [];
+  historian.sensorsInfo.Apps.map(function(app) {
+    var optionText = app.PackageName + ' (Uid: ' + app.UID + ')';
+    var appOption = new Option(optionText, app.UID);
+    allAppOptions.push(appOption);
+  });
+  allAppOptions.forEach(function(appOpt) {
+    filterAppSelector.append(appOpt);
+  });
+}

--- a/sensorserviceutils/sensorserviceutils.go
+++ b/sensorserviceutils/sensorserviceutils.go
@@ -927,7 +927,7 @@ func (p *parser) processActivation(timestampMs int64, sensorNumber, uid int32,
 		} else {
 			value := fmt.Sprintf("InvalidActivation,%s,%s,%d",
 				msToTime(timestampMs).In(p.loc).Format(timeFormat),
-				conn.GetPackageName(), conn.GetUID())
+				packageName, uid)
 			p.csvState.PrintInstantEvent(csv.Entry{
 				Desc:  p.sensors[sensorNumber].GetName(),
 				Start: timestampMs,

--- a/sensorserviceutils/sensorserviceutils_test.go
+++ b/sensorserviceutils/sensorserviceutils_test.go
@@ -15,7 +15,6 @@
 package sensorserviceutils
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -90,10 +89,9 @@ func TestParseSet1(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name, finput     string
-		wantActiveConn   []*sipb.ActiveConn
-		wantCSV          string
-		wantSensorErrors []error
+		name, finput   string
+		wantActiveConn []*sipb.ActiveConn
+		wantCSV        string
 	}{
 		{
 			name: "[Active Sensor and Connections] Test 1: " +
@@ -416,12 +414,10 @@ func TestParseSet1(t *testing.T) {
 			},
 			wantCSV: strings.Join([]string{
 				csv.FileHeader,
+				`BMP280 pressure,error,1436292420000,1436292420000,"SensorNotActive,18:07:00,com.google.android.location.collectionlib.w,10013",`,
 				`BMI160 Step counter,string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,24,ON_CHANGE,10013,com.google.android.gms.fitness.sensors.d.b,4.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`BMP280 pressure,string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,4,CONTINUOUS,10013,com.google.android.location.collectionlib.w,-1.00,-1.00,Sensorservice Dump,isActiveConn",`,
 			}, "\n"),
-			wantSensorErrors: []error{
-				fmt.Errorf("[Active Connection]: connection(2): the sensor(4) is not active according to the sensor device section"),
-			},
 		},
 		{
 			name: "[History] Test 1: " +
@@ -658,18 +654,16 @@ func TestParseSet1(t *testing.T) {
 			},
 			wantCSV: strings.Join([]string{
 				csv.FileHeader,
+				`BMI160 accelerometer,error,1436292420000,1436292420000,"SensorNotActive,18:07:00,civ,10182",`,
+				`BMI160 accelerometer,error,1436292001000,1436292001000,"TwoSamplingRate,18:00:01,civ,10182,-1.00,400.00",`,
+				`BMI160 accelerometer,error,1436292001000,1436292001000,"TwoBatchingPeriod,18:00:01,civ,10182,-1.00,0.00",`,
 				`BMI160 accelerometer,string,1436292001000,1436292420000,"18:00:01,1436292001000,18:07:00,1436292420000,1,CONTINUOUS,10182,civ,400.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`BMI160 Step counter,string,1436291941000,1436292420000,"17:59:01,1436291941000,18:07:00,1436292420000,24,ON_CHANGE,10013,com.google.android.gms.fitness.sensors.d.b,4.00,0.00,Sensorservice Dump,isActiveConn",`,
+				`RPR0521 light,error,1436290801000,1436290801000,"TwoBatchingPeriod,17:40:01,com.android.server.display.AutomaticBrightnessController,1000,0.10,0.00",`,
 				`RPR0521 light,string,1436290801000,1436292420000,"17:40:01,1436290801000,18:07:00,1436292420000,7,ON_CHANGE,1000,com.android.server.display.AutomaticBrightnessController,5.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`BMP280 pressure,string,1436290211000,1436292420000,"17:30:11,1436290211000,18:07:00,1436292420000,4,CONTINUOUS,10013,com.google.android.location.collectionlib.w,15.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`Window Orientation,string,1436290211000,1436292420000,"17:30:11,1436290211000,18:07:00,1436292420000,31,ON_CHANGE,1000,com.android.server.policy.WindowOrientationListener,50.00,0.00,Sensorservice Dump,isActiveConn",`,
 			}, "\n"),
-			wantSensorErrors: []error{
-				fmt.Errorf("[Active Connection]: connection(5): the sensor(1) is not active according to the sensor device section"),
-				fmt.Errorf("[Active Sensor]: active connection for pkg(civ) and sensor(1) shows two sampling rate(Hz): -1.00 at active sensor section; 400.00 at history section"),
-				fmt.Errorf("[Active Sensor]: active connection for pkg(civ) and sensor(1) shows two batching period(s): -1.00 at active sensor section; 0.00 at history section"),
-				fmt.Errorf("[Active Sensor]: active connection for pkg(com.android.server.display.AutomaticBrightnessController) and sensor(7) shows two batching period(s): 0.10 at active sensor section; 0.00 at history section"),
-			},
 		},
 		{
 			name: "[History] Test 3: " +
@@ -936,16 +930,14 @@ func TestParseSet1(t *testing.T) {
 				`BMP280 pressure,string,1436291941000,1436292420000,"17:59:01,1436291941000,18:07:00,1436292420000,4,CONTINUOUS,10013,com.google.android.location.collectionlib.w,15.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`BMI160 accelerometer,string,1436291671000,1436292420000,"17:54:31,1436291671000,18:07:00,1436292420000,1,CONTINUOUS,10182,civ,50.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`RPR0521 light,string,1436291579000,1436291867000,"17:52:59,1436291579000,17:57:47,1436291867000,7,ON_CHANGE,321,AA,5.00,0.10,Sensorservice Dump",`,
+				`BMI160 accelerometer,error,1436291515000,1436291515000,"InvalidActivation,17:51:55,DD,985",`,
 				`RPR0521 light,string,1436291403000,1436292420000,"17:50:03,1436291403000,18:07:00,1436292420000,7,ON_CHANGE,1000,com.android.server.display.AutomaticBrightnessController,5.00,0.10,Sensorservice Dump,isActiveConn",`,
 				`Window Orientation,string,1436290921000,1436292420000,"17:42:01,1436290921000,18:07:00,1436292420000,31,ON_CHANGE,1000,com.android.server.policy.WindowOrientationListener,50.00,0.00,Sensorservice Dump,isActiveConn",`,
+				`BMI160 Step counter,error,1436291132000,1436291132000,"MultipleDe-Activation,17:45:32,CCC,135",`,
 				`BMI160 Step counter,string,1436290861000,1436291193000,"17:41:01,1436290861000,17:46:33,1436291193000,24,ON_CHANGE,135,CCC,4.00,0.00,Sensorservice Dump",`,
 				`BMP280 pressure,string,1436290809000,1436291327000,"17:40:09,1436290809000,17:48:47,1436291327000,4,CONTINUOUS,654,BB,15.00,0.00,Sensorservice Dump",`,
+				`BMP280 pressure,error,1436291327000,1436291327000,"MultipleActivation,17:48:47,BB,654",`,
 			}, "\n"),
-			wantSensorErrors: []error{
-				fmt.Errorf("[Invalid Activation]: connection between pkg(DD) and sensor(1) should be active"),
-				fmt.Errorf("[Multiple De-Activation]: for pkg(CCC) and sensor(24)"),
-				fmt.Errorf("[Multiple Activation]: for pkg(BB) and sensor(4)"),
-			},
 		},
 	}
 	for _, test := range tests {
@@ -962,21 +954,15 @@ func TestParseSet1(t *testing.T) {
 				test.name, gotCSV, wantCSV)
 			break
 		}
-		if !reflect.DeepEqual(OutputData.SensorErrs, test.wantSensorErrors) {
-			t.Errorf("SensorErrors: %v:\n  got errs: %v\n want errs: %v",
-				test.name, OutputData.SensorErrs, test.wantSensorErrors)
-			break
-		}
 	}
 }
 
 func TestParseSet2(t *testing.T) {
 	tests := []struct {
-		name, finput     string
-		meta             *bugreportutils.MetaInfo
-		wantActiveConn   []*sipb.ActiveConn
-		wantCSV          string
-		wantSensorErrors []error
+		name, finput   string
+		meta           *bugreportutils.MetaInfo
+		wantActiveConn []*sipb.ActiveConn
+		wantCSV        string
 	}{
 		{
 			name: "Multiple Sensors with the same name and same type",
@@ -1491,6 +1477,9 @@ func TestParseSet2(t *testing.T) {
 			},
 			wantCSV: strings.Join([]string{
 				csv.FileHeader,
+				`4.BMI160 accelerometer (accelerometer),error,1436292420000,1436292420000,"SensorNotActive,18:07:00,C,1000",`,
+				`5.BMI160 accelerometer (accelerometer1),error,1436292420000,1436292420000,"SensorNotActive,18:07:00,C,12345",`,
+				`6.BMI160 accelerometer (accelerometer1),error,1436292420000,1436292420000,"SensorNotActive,18:07:00,C,12345",`,
 				`2.BMI160 accelerometer (accelerometer1),string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,2,CONTINUOUS,10013,A,15.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`1.BMI160 accelerometer (accelerometer),string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,1,CONTINUOUS,10086,A,4.00,0.00,Sensorservice Dump,isActiveConn",`,
 				`BMI160 accelerometer (accelerometer2),string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,3,CONTINUOUS,1000,B,5.00,0.10,Sensorservice Dump,isActiveConn",`,
@@ -1498,11 +1487,6 @@ func TestParseSet2(t *testing.T) {
 				`5.BMI160 accelerometer (accelerometer1),string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,5,CONTINUOUS,12345,C,-1.00,-1.00,Sensorservice Dump,isActiveConn",`,
 				`6.BMI160 accelerometer (accelerometer1),string,1436292420000,1436292420000,"18:07:00,1436292420000,18:07:00,1436292420000,6,CONTINUOUS,12345,C,-1.00,-1.00,Sensorservice Dump,isActiveConn",`,
 			}, "\n"),
-			wantSensorErrors: []error{
-				fmt.Errorf("[Active Connection]: connection(4): the sensor(4) is not active according to the sensor device section"),
-				fmt.Errorf("[Active Connection]: connection(5): the sensor(5) is not active according to the sensor device section"),
-				fmt.Errorf("[Active Connection]: connection(6): the sensor(6) is not active according to the sensor device section"),
-			},
 		},
 	}
 	for _, test := range tests {
@@ -1516,10 +1500,6 @@ func TestParseSet2(t *testing.T) {
 		if !reflect.DeepEqual(gotCSV, wantCSV) {
 			t.Errorf("History does not match: %v:\n  got: %v\n want: %v",
 				test.name, gotCSV, wantCSV)
-		}
-		if !reflect.DeepEqual(OutputData.SensorErrs, test.wantSensorErrors) {
-			t.Errorf("SensorErrors: %v:\n  got errs: %v\n want errs: %v",
-				test.name, OutputData.SensorErrs, test.wantSensorErrors)
 		}
 	}
 }
@@ -1589,11 +1569,10 @@ func TestParseSet3(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name, finput     string
-		wantActiveConn   []*sipb.ActiveConn
-		wantDirectConn   []*sipb.DirectConn
-		wantCSV          string
-		wantSensorErrors []error
+		name, finput   string
+		wantActiveConn []*sipb.ActiveConn
+		wantDirectConn []*sipb.DirectConn
+		wantCSV        string
 	}{
 		{
 			name: "[Direct Connections] Test 1: " +
@@ -1880,11 +1859,6 @@ func TestParseSet3(t *testing.T) {
 		if !reflect.DeepEqual(gotCSV, wantCSV) {
 			t.Errorf("History does not match: %v:\n  got: %v\n want: %v",
 				test.name, gotCSV, wantCSV)
-		}
-		if !reflect.DeepEqual(OutputData.SensorErrs, test.wantSensorErrors) {
-			t.Errorf("SensorErrors: %v:\n  got errs: %v\n want errs: %v",
-				test.name, OutputData.SensorErrs, test.wantSensorErrors)
-			break
 		}
 	}
 }


### PR DESCRIPTION
1. A selector is added to support the filter by app feature. The other selector can be used to add sensor activities into the graph. Here is the graph without selecting anything.
![Screen Shot 2020-07-30 at 15 52 57](https://user-images.githubusercontent.com/32555113/88968153-e5b76300-d27c-11ea-9b36-9ad9da49e1f2.png)
After selecting an app, only sensors related to this app will be shown on the graph. Note that all events shown are activities for this app.
![Screen Shot 2020-07-30 at 15 53 12](https://user-images.githubusercontent.com/32555113/88968156-e7812680-d27c-11ea-9b65-0e5dd0796e1f.png)
Sensor errors will be marked using a circle. When moving the mouse to the circle, we can see details for the errors seen at that time.
![Screen Shot 2020-07-30 at 15 53 33](https://user-images.githubusercontent.com/32555113/88968161-e9e38080-d27c-11ea-9283-c10a7b5eb5a5.png)
